### PR TITLE
Add script for printing product table

### DIFF
--- a/parse_products.py
+++ b/parse_products.py
@@ -1,0 +1,46 @@
+import argparse
+import pandas as pd
+from tabulate import tabulate
+import os
+
+FIELDS = [
+    "ID",
+    "Type",
+    "SKU",
+    "Name",
+    "Description",
+    "Short description",
+    "Regular price",
+    "Sale price",
+    "Categories",
+    "Images",
+    "Stock status",
+    "Stock quantity",
+]
+
+def load_file(path: str) -> pd.DataFrame:
+    ext = os.path.splitext(path)[1].lower()
+    if ext in {".xlsx", ".xls"}:
+        df = pd.read_excel(path)
+    else:
+        df = pd.read_csv(path)
+    return df
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Print product table from file")
+    parser.add_argument("file", help="Path to CSV or Excel file with product data")
+    args = parser.parse_args()
+
+    df = load_file(args.file)
+
+    # Ensure all fields exist
+    for col in FIELDS:
+        if col not in df.columns:
+            df[col] = ""
+
+    print(tabulate(df[FIELDS], headers=FIELDS, tablefmt="pretty", showindex=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide a new `parse_products.py` utility
- script loads a CSV or Excel file and prints a table of product info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855104a6d908327a700cf1080fc0cf0